### PR TITLE
ci: fix workflow for cf wrangler

### DIFF
--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -20,10 +20,11 @@ jobs:
       - run: yarn generate
 
       - name: Publish to Cloudflare Workers Sites
-        run: |
-          mkdir -p ~/.wrangler/config/
-          echo "api_token=\"${CF_API_TOKEN}\"" > ~/.wrangler/config/default.toml
-          yarn wrangler publish --env production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: deploy --env production
         env:
           SECRETS_ENC_KEY: ${{ secrets.SECRETS_ENC_KEY }}
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
This changes the workflow to utilise the premade github action 